### PR TITLE
Added missing header name to signing error message

### DIFF
--- a/sigbase/derive.go
+++ b/sigbase/derive.go
@@ -23,7 +23,7 @@ func Derive(params sigparams.Params, w http.ResponseWriter, req *http.Request, d
 
 		val, err := getComponentValue(cc, w, req, digester)
 		if err != nil {
-			return nil, fmt.Errorf("identifier %q: %w", val, err)
+			return nil, fmt.Errorf("identifier %q %q: %w", cc, val, err)
 		}
 
 		base.Values[cc] = val


### PR DESCRIPTION
The current error if a request is missing a required header is:
```
deriving signature base: identifier "": HTTP header was empty
```

This change adds the missing component name, to ease debugging of a missing identifier
```
deriving signature base: identifier "content-type" "": HTTP header was empty
```