### PR TITLE
Adding @path to the list of valid derived components

### DIFF
--- a/sigbase/component_value.go
+++ b/sigbase/component_value.go
@@ -89,6 +89,13 @@ func getComponentValue(identifier string, w http.ResponseWriter, r *http.Request
 		}
 		return val, nil
 
+	case "@path":
+		val := r.URL.Path
+		if val == "" {
+			val = "/"
+		}
+		return val, nil
+
 	case "content-length":
 		return httpsfv.Marshal(httpsfv.NewItem(r.ContentLength))
 

--- a/sigbase/component_value_test.go
+++ b/sigbase/component_value_test.go
@@ -64,6 +64,28 @@ func Test_getComponentValue(t *testing.T) {
 			want: "example.com",
 		},
 		{
+			name: "empty_path",
+			args: args{
+				identifier: "@path",
+				r: func() *http.Request {
+					req, _ := http.NewRequest("POST", "https://example.com", nil)
+					return req
+				},
+			},
+			want: "/",
+		},
+		{
+			name: "non-empty_path",
+			args: args{
+				identifier: "@path",
+				r: func() *http.Request {
+					req, _ := http.NewRequest("POST", "https://example.com/foo/bar-123", nil)
+					return req
+				},
+			},
+			want: "/foo/bar-123",
+		},
+		{
 			name: "header_value",
 			args: args{
 				identifier: "my-header",


### PR DESCRIPTION
In my integration of httpsig with my GoActivityPub library I encountered a couple of issues when trying to use the test cases in the RFC for validating the code.

The first one was that [`@path`](https://www.rfc-editor.org/rfc/rfc9421.html#name-path) wasn't a valid derived component, so I took the liberty to add it.

Let me know if this PR is acceptable, and thank you for creating this. :muscle: 